### PR TITLE
(Feat) Implement FHIR to OpenMRS Form Translator

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2extension/FhirConstants.java
+++ b/api/src/main/java/org/openmrs/module/fhir2extension/FhirConstants.java
@@ -31,12 +31,14 @@
 package org.openmrs.module.fhir2extension;
 
 public final class FhirConstants {
-	
-	private FhirConstants() {
-	}
-	
-	public static final String QUESTIONNAIRE = "Questionnaire";
-	
-	public static final String FHIR_QUESTIONNAIRE_TYPE = "FHIR Questionnaire";
-	
+
+    private FhirConstants() {
+    }
+
+    public static final String QUESTIONNAIRE = "Questionnaire";
+
+    public static final String FHIR_QUESTIONNAIRE_TYPE = "FHIR Questionnaire";
+
+    public static final String FORM_SYSTEM_URI = "http://fhir.openmrs.org/core/StructureDefinition/omrs-form";
+
 }

--- a/api/src/main/java/org/openmrs/module/fhir2extension/api/impl/EncounterTranslatorExtensionImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2extension/api/impl/EncounterTranslatorExtensionImpl.java
@@ -1,0 +1,92 @@
+/*
+ * with Copyright 2024 ICRC
+ *
+ * BSD 3-Clause License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openmrs.module.fhir2extension.api.impl;
+
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Encounter;
+import org.openmrs.Form;
+import org.openmrs.module.fhir2.api.translators.impl.EncounterTranslatorImpl;
+import org.openmrs.module.fhir2extension.FhirConstants;
+import org.openmrs.module.fhir2extension.api.translators.FormTranslator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+@Primary
+@Component
+public class EncounterTranslatorExtensionImpl extends EncounterTranslatorImpl {
+
+    @Autowired
+    private FormTranslator<Form> formTranslator;
+
+    @Override
+    public Encounter toFhirResource(@Nonnull org.openmrs.Encounter openmrsEncounter) {
+        notNull(openmrsEncounter, "The Openmrs Encounter object should not be null");
+
+        Encounter encounter = super.toFhirResource(openmrsEncounter);
+
+        return encounter;
+    }
+
+    @Override
+    public org.openmrs.Encounter toOpenmrsType(@Nonnull Encounter fhirEncounter) {
+        notNull(fhirEncounter, "The Encounter object should not be null");
+        return this.toOpenmrsType(new org.openmrs.Encounter(), fhirEncounter);
+    }
+
+    @Override
+    public org.openmrs.Encounter toOpenmrsType(@Nonnull org.openmrs.Encounter existingEncounter,
+                                               @Nonnull Encounter encounter) {
+        super.toOpenmrsType(existingEncounter, encounter);
+        notNull(existingEncounter, "The existing Openmrs Encounter object should not be null");
+        notNull(encounter, "The Encounter object should not be null");
+
+        CodeableConcept formType = encounter.getType().stream()
+                .filter(codeableConcept -> codeableConcept.getCoding().stream()
+                        .anyMatch(coding -> FhirConstants.FORM_SYSTEM_URI.equals(coding.getSystem())))
+                .findFirst()
+                .orElse(null);
+
+        Form form = formTranslator.toOpenmrsType(formType);
+
+        if (formType != null) {
+            notNull(form, "The Form object should not be null");
+        }
+
+        existingEncounter.setForm(form);
+
+        return existingEncounter;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/fhir2extension/api/impl/EncounterTranslatorExtensionImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2extension/api/impl/EncounterTranslatorExtensionImpl.java
@@ -47,31 +47,20 @@ import static org.apache.commons.lang3.Validate.notNull;
 @Primary
 @Component
 public class EncounterTranslatorExtensionImpl extends EncounterTranslatorImpl {
-
-    @Autowired
-    private FormTranslator<Form> formTranslator;
-
-    @Override
-    public Encounter toFhirResource(@Nonnull org.openmrs.Encounter openmrsEncounter) {
-        notNull(openmrsEncounter, "The Openmrs Encounter object should not be null");
-
-        Encounter encounter = super.toFhirResource(openmrsEncounter);
-
-        return encounter;
-    }
-
-    @Override
-    public org.openmrs.Encounter toOpenmrsType(@Nonnull Encounter fhirEncounter) {
-        notNull(fhirEncounter, "The Encounter object should not be null");
-        return this.toOpenmrsType(new org.openmrs.Encounter(), fhirEncounter);
-    }
-
-    @Override
+	
+	@Autowired
+	private FormTranslator<Form> formTranslator;
+	
+	@Override
+	public org.openmrs.Encounter toOpenmrsType(@Nonnull Encounter fhirEncounter) {
+		notNull(fhirEncounter, "The Encounter object should not be null");
+		return this.toOpenmrsType(new org.openmrs.Encounter(), fhirEncounter);
+	}
+	
+	@Override
     public org.openmrs.Encounter toOpenmrsType(@Nonnull org.openmrs.Encounter existingEncounter,
                                                @Nonnull Encounter encounter) {
         super.toOpenmrsType(existingEncounter, encounter);
-        notNull(existingEncounter, "The existing Openmrs Encounter object should not be null");
-        notNull(encounter, "The Encounter object should not be null");
 
         CodeableConcept formType = encounter.getType().stream()
                 .filter(codeableConcept -> codeableConcept.getCoding().stream()

--- a/api/src/main/java/org/openmrs/module/fhir2extension/api/translators/FormTranslator.java
+++ b/api/src/main/java/org/openmrs/module/fhir2extension/api/translators/FormTranslator.java
@@ -1,11 +1,33 @@
 package org.openmrs.module.fhir2extension.api.translators;/*
- * This Source Code Form is subject to the terms of the Mozilla Public License,
- * v. 2.0. If a copy of the MPL was not distributed with this file, You can
- * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
- * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+/*
+ * with Copyright 2024 ICRC
  *
- * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
- * graphic logo is a trademark of OpenMRS Inc.
+ * BSD 3-Clause License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 import org.hl7.fhir.r4.model.CodeableConcept;

--- a/api/src/main/java/org/openmrs/module/fhir2extension/api/translators/FormTranslator.java
+++ b/api/src/main/java/org/openmrs/module/fhir2extension/api/translators/FormTranslator.java
@@ -1,0 +1,29 @@
+package org.openmrs.module.fhir2extension.api.translators;/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.openmrs.module.fhir2.api.translators.OpenmrsFhirTranslator;
+
+public interface FormTranslator<T> extends OpenmrsFhirTranslator<T, CodeableConcept> {
+
+    /**
+     * @param form the OpenMRS form to translate
+     * @return a list consisting of an encoded version of the OpenMRS form
+     */
+    @Override
+    CodeableConcept toFhirResource(T form);
+
+    /**
+     * @param form a list consisting of an encoded version of the OpenMRS form
+     * @return the OpenMRS encounter type or visit type
+     */
+    @Override
+    T toOpenmrsType(CodeableConcept form);
+}

--- a/api/src/main/java/org/openmrs/module/fhir2extension/api/translators/impl/FormTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2extension/api/translators/impl/FormTranslatorImpl.java
@@ -1,0 +1,58 @@
+package org.openmrs.module.fhir2extension.api.translators.impl;/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.openmrs.Form;
+import org.openmrs.api.FormService;
+import org.openmrs.module.fhir2extension.api.translators.FormTranslator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import static org.openmrs.module.fhir2.api.util.FhirUtils.getMetadataTranslation;
+
+@Component
+public class FormTranslatorImpl implements FormTranslator<Form> {
+
+    public static final String FORM_SYSTEM_URI = "http://fhir.openmrs.org/core/StructureDefinition/omrs-form";
+
+    @Autowired
+    private FormService formService;
+
+    @Override
+    public CodeableConcept toFhirResource(Form form) {
+        if (form == null) {
+            return null;
+        }
+
+        CodeableConcept code = new CodeableConcept();
+        code.addCoding().setSystem(FORM_SYSTEM_URI).setCode(form.getUuid()).setDisplay(getMetadataTranslation(form));
+
+        return code;
+    }
+
+    @Override
+    public Form toOpenmrsType(CodeableConcept form) {
+        if (form == null || !form.hasCoding()) {
+            return null;
+        }
+        Coding coding = form.getCoding().stream()
+                .filter(Coding::hasSystem)
+                .filter(c -> FORM_SYSTEM_URI.equals(c.getSystem()))
+                .findFirst()
+                .orElse(null);
+
+        if (coding == null) {
+            return null;
+        }
+
+        return formService.getFormByUuid(coding.getCode());
+    }
+}

--- a/api/src/main/java/org/openmrs/module/fhir2extension/api/translators/impl/FormTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2extension/api/translators/impl/FormTranslatorImpl.java
@@ -1,11 +1,33 @@
 package org.openmrs.module.fhir2extension.api.translators.impl;/*
- * This Source Code Form is subject to the terms of the Mozilla Public License,
- * v. 2.0. If a copy of the MPL was not distributed with this file, You can
- * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
- * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+/*
+ * with Copyright 2024 ICRC
  *
- * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
- * graphic logo is a trademark of OpenMRS Inc.
+ * BSD 3-Clause License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 import org.hl7.fhir.r4.model.CodeableConcept;

--- a/api/src/test/java/org/openmrs/module/fhir2extension/providers/r4/QuestionnaireFhirResourceProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2extension/providers/r4/QuestionnaireFhirResourceProviderTest.java
@@ -1,11 +1,32 @@
 /*
- * This Source Code Form is subject to the terms of the Mozilla Public License,
- * v. 2.0. If a copy of the MPL was not distributed with this file, You can
- * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
- * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ * with Copyright 2024 ICRC
  *
- * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
- * graphic logo is a trademark of OpenMRS Inc.
+ * BSD 3-Clause License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.openmrs.module.fhir2extension.providers.r4;
 


### PR DESCRIPTION
This PR introduces a form translation layer to enable seamless integration between FHIR and OpenMRS form-based encounters. With this update, users can create an encounter in OpenMRS via FHIR while ensuring the `form_id` field is populated, which allows the form to be opened correctly in the OpenMRS web application.

### Key Changes
Form Translation Logic: Added functionality to bridge FHIR and OpenMRS forms by mapping form identifiers and types from FHIR to OpenMRS.

**Form Specification:** The encounter object now includes an additional type field to identify the form, structured as follows:

```
{
  "coding": [
    {
      "system": "http://fhir.openmrs.org/core/StructureDefinition/omrs-form",
      "code": "<FORM_UUID>",
      "display": "FORM_NAME"
    }
  ]
}
```
**Form Identification in FHIR:** This allows FHIR to set the correct form_id in OpenMRS, enabling direct navigation to the corresponding form within the OpenMRS web UI.