### PR TITLE
(feat) Generate patient identifiers using openmrs idgen

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -26,6 +26,11 @@
 			<artifactId>openmrs-api</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.openmrs.module</groupId>
+			<artifactId>idgen-api</artifactId>
+			<version>4.14.0</version>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 		</dependency>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -20,6 +20,7 @@
     <!-- Require Modules -->
     <require_modules>
         <require_module>org.openmrs.module.fhir2</require_module>
+        <require_module>org.openmrs.module.idgen</require_module>
     </require_modules>
 
     <messages>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,12 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>org.openmrs.module</groupId>
+                <artifactId>idgen-api</artifactId>
+                <version>4.14.0</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junitVersion}</version>


### PR DESCRIPTION
### Summary

- Feature: Generate patient identifiers using OpenMRS IDGEN module.

### Description
This PR integrates OpenMRS IDGEN to automatically generate patient identifiers during patient registration. It ensures all new patients receive a valid, unique identifier compliant with the configured IDGEN source.

### Changes

- Added service integration with OpenMRS IDGEN API.
- Updated patient registration flow to fetch and assign identifiers from IDGEN.
- Minor refactoring to registration service for better separation of concerns.

